### PR TITLE
Fixes out of date footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -180,7 +180,7 @@
       </div>
     </div>
   </div>
-  <footer class="mt-5 text-center text-dark position-relative footer opacity-0 w-100 bottom-0 mb-1">©2021 Zach Neill |
+  <footer class="mt-5 text-center text-dark position-relative footer opacity-0 w-100 bottom-0 mb-1">©<script>document.write(new Date().getFullYear())</script> Zach Neill |
     <span>
       <a class="p-0 btn" href="https://github.com/zachneill" target="_blank"><span class="text-white bi bi-github"></span></a>
       <a class="p-0 btn" href="https://www.linkedin.com/in/zach-neill-0a957b197/" target="_blank"><span class="text-white bi bi-linkedin"></span></a>

--- a/contact.html
+++ b/contact.html
@@ -66,7 +66,7 @@
     <strong>Success!</strong> I will receive this message shortly :)
     <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
   </div>
-  <footer class="mt-5 text-center text-dark position-relative footer opacity-0 w-100 bottom-0 mb-1">©2021 Zach Neill |
+  <footer class="mt-5 text-center text-dark position-relative footer opacity-0 w-100 bottom-0 mb-1">©<script>document.write(new Date().getFullYear())</script> Zach Neill |
     <span>
       <a class="p-0 btn" href="https://github.com/zachneill" target="_blank"><span class="text-white bi bi-github"></span></a>
       <a class="p-0 btn" href="https://www.linkedin.com/in/zach-neill-0a957b197/" target="_blank"><span class="text-white bi bi-linkedin"></span></a>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
     <br class="my-5">
     <div class="br-10"></div>
   </div>
-  <footer class="mt-5 text-center text-dark position-relative footer opacity-0 w-100 bottom-0 mb-1">©2021 Zach Neill |
+  <footer class="mt-5 text-center text-dark position-relative footer opacity-0 w-100 bottom-0 mb-1">©<script>document.write(new Date().getFullYear())</script> Zach Neill |
     <span>
       <a class="p-0 btn" href="https://github.com/zachneill" target="_blank"><span class="text-white bi bi-github"></span></a>
       <a class="p-0 btn" href="https://www.linkedin.com/in/zach-neill-0a957b197/" target="_blank"><span class="text-white bi bi-linkedin"></span></a>


### PR DESCRIPTION
This PR is for issue #1 

The footer uses an inline style tag to get the current full year and display it in the footer. --> ©UPTODATEYEAR Zach Neill

To test, go to the about, index, and contact pages. 2021 should no longer be there in favor of the current year.